### PR TITLE
Fixed the render issue on android 7.0. 

### DIFF
--- a/react-native-androw/android/src/main/java/se/folof/androw/RNAndrowLayout.java
+++ b/react-native-androw/android/src/main/java/se/folof/androw/RNAndrowLayout.java
@@ -175,9 +175,9 @@ public class RNAndrowLayout extends ReactViewGroup {
                 canvas.drawBitmap(shadow, x, y, paint);
             }
             canvas.drawBitmap(content, 0f, 0f, null);
-        } else {
-            super.dispatchDraw(canvas);
         }
-
+        
+        super.dispatchDraw(canvas);
+      
     }
 }


### PR DESCRIPTION
Allowed super.dispatchDraw(canvas) always in dispatchDraw(canvas) .